### PR TITLE
Integrate remotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ npm run build
 
 
 
+
+### Remotion重构
+
+项目已引入 [Remotion](https://www.remotion.dev/) 用于视频渲染，原有的 typeMonkey 字幕特效在 `src/remotion` 中通过 React 组件封装。
+
+```bash
+# 预览视频
+npm run preview
+
+# 导出视频
+npm run render TypeMonkey out.mp4
+```

--- a/package.json
+++ b/package.json
@@ -6,10 +6,17 @@
   "scripts": {
     "gulp": "./node_modules/.bin/gulp",
     "dev": "gulp",
-    "build": "gulp build"
+    "build": "gulp build",
+    "preview": "remotion preview",
+    "render": "remotion render"
   },
   "author": "nostar",
   "license": "ISC",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "remotion": "^3.3.2"
+  },
   "devDependencies": {
     "babel-preset-es2015": "^6.9.0",
     "browser-sync": "^2.13.0",

--- a/remotion.config.ts
+++ b/remotion.config.ts
@@ -1,0 +1,3 @@
+import {Config} from 'remotion';
+
+Config.setImageFormat('jpeg');

--- a/src/js/typemoneky.js
+++ b/src/js/typemoneky.js
@@ -328,3 +328,5 @@ class TypeMoneky {
     })()
   }
 }
+
+export default TypeMoneky;

--- a/src/remotion/Root.tsx
+++ b/src/remotion/Root.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {Composition, registerRoot} from 'remotion';
+import {TypeMonkeyVideo} from './TypeMonkeyVideo';
+
+const list = [
+  {type: 'text', value: 'Hello Remotion'},
+  {type: 'text', value: 'typeMonkey字幕特效'}
+];
+
+const RemotionRoot: React.FC = () => (
+  <>
+    <Composition
+      id="TypeMonkey"
+      component={() => <TypeMonkeyVideo list={list} />}
+      durationInFrames={150}
+      fps={30}
+      width={1080}
+      height={1080}
+    />
+  </>
+);
+
+registerRoot(RemotionRoot);

--- a/src/remotion/TypeMonkeyVideo.tsx
+++ b/src/remotion/TypeMonkeyVideo.tsx
@@ -1,0 +1,26 @@
+import React, {useEffect, useRef} from 'react';
+import TypeMoneky from '../js/typemoneky';
+
+export const TypeMonkeyVideo: React.FC<{list: any[]}> = ({list}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const tm = new TypeMoneky({
+      box: ref.current,
+      list,
+      background: 'transparent',
+      beforeCreate(next: () => void) {
+        next();
+      },
+      afterEnd() {}
+    });
+    tm.init();
+    tm.start();
+    return () => {
+      tm.clear();
+    };
+  }, [list]);
+
+  return <div ref={ref} style={{width: '100%', height: '100%'}} />;
+};


### PR DESCRIPTION
## Summary
- export `TypeMoneky` class for module use
- add Remotion demo components and config
- wire up Remotion scripts and deps in `package.json`
- document Remotion usage

## Testing
- `npm run build` *(fails: gulp not found)*

------
https://chatgpt.com/codex/tasks/task_e_685addbcb1c48324ad367433d757c58c